### PR TITLE
Fix removing lazy initialization of repository state

### DIFF
--- a/environment.c
+++ b/environment.c
@@ -203,8 +203,7 @@ int is_bare_repository(void)
 
 int have_git_dir(void)
 {
-	return startup_info->have_repository
-		|| the_repository->gitdir;
+	return the_repository->gitdir ? 1 : 0;
 }
 
 const char *get_git_dir(void)


### PR DESCRIPTION
This commit is the cause of the error: https://github.com/TortoiseGit/tgit/commit/73f192c991016bf88a9416cdf0e949f8b946f7e2
Lazy initialization was removed incorrectly! 
After these changes, the dependent code began to work incorrectly:
https://github.com/TortoiseGit/TortoiseGit/blob/364ebc6e686828b24964845bdb52445b645b9e27/ext/gitdll/gitdll.c#L888-L890
